### PR TITLE
Updates needed to collect EFS (and later S3) usage data

### DIFF
--- a/accounting_service/app/app.py
+++ b/accounting_service/app/app.py
@@ -12,7 +12,12 @@ from sqlalchemy import Result, Row
 from sqlalchemy.orm import Session
 
 from accounting_service.db import get_session
-from accounting_service.models import BillingEvent, BillingItem, BillingItemPrice
+from accounting_service.models import (
+    BillingEvent,
+    BillingItem,
+    BillingItemPrice,
+    datetime_default_to_utc,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -221,6 +226,9 @@ def get_workspace_usage_data(
     Consumption data may be aggregated so that the time periods used get longer, but they will
     never be aggregated across day boundaries (midnight UTC).
     """
+    start = datetime_default_to_utc(start)
+    end = datetime_default_to_utc(end)
+
     events: Iterator[BillingEvent] = BillingEvent.find_billing_events(
         session, workspace=workspace, start=start, end=end, limit=limit or 100, after=after
     )
@@ -296,6 +304,9 @@ def get_account_usage_data(
     Consumption data may be aggregated so that the time periods used get longer, but they will
     never be aggregated across day boundaries (midnight UTC).
     """
+    start = datetime_default_to_utc(start)
+    end = datetime_default_to_utc(end)
+
     events: Iterator[BillingEvent] = BillingEvent.find_billing_events(
         session, account=account_id, start=start, end=end, limit=limit or 100, after=after
     )

--- a/accounting_service/app/app.py
+++ b/accounting_service/app/app.py
@@ -17,7 +17,7 @@ from accounting_service.models import BillingEvent, BillingItem, BillingItemPric
 logger = logging.getLogger(__name__)
 
 setup_logging(verbosity=1)
-log_component_version("annotations_api")
+log_component_version("accounting-service")
 
 
 root_path = os.environ.get("ROOT_PATH", "/api/")

--- a/accounting_service/ingester/__main__.py
+++ b/accounting_service/ingester/__main__.py
@@ -14,7 +14,7 @@ from accounting_service.ingester.messager import (
 @click.option("--pulsar-url")
 def cli(takeover: bool, verbose: int, pulsar_url=None):
     setup_logging(verbosity=verbose)
-    log_component_version("annotations_ingester")
+    log_component_version("accounting-service")
 
     db.create_db_and_tables()
 

--- a/accounting_service/ingester/__main__.py
+++ b/accounting_service/ingester/__main__.py
@@ -4,6 +4,7 @@ from eodhp_utils.runner import log_component_version, run, setup_logging
 from accounting_service import db
 from accounting_service.ingester.messager import (
     AccountingIngesterMessager,
+    ConsumptionSampleRateIngesterMessager,
     WorkspaceSettingsIngesterMessager,
 )
 
@@ -22,6 +23,7 @@ def cli(takeover: bool, verbose: int, pulsar_url=None):
         {
             "billing-events": AccountingIngesterMessager(),
             "workspace-settings": WorkspaceSettingsIngesterMessager(),
+            "billing-events-consumption-rate-samples": ConsumptionSampleRateIngesterMessager(),
         },
         "accounting-ingester",
         takeover_mode=takeover,

--- a/accounting_service/ingester/messager.py
+++ b/accounting_service/ingester/messager.py
@@ -18,7 +18,7 @@ class DBIngester:
         return False
 
 
-class AccountingIngesterMessager(DBIngester, PulsarJSONMessager[messages.BillingEvent]):
+class AccountingIngesterMessager(DBIngester, PulsarJSONMessager[messages.BillingEvent, bytes]):
     """
     This Messager receives Pulsar messages containing billing events and updates the
     accounting DB.
@@ -60,7 +60,9 @@ class AccountingIngesterMessager(DBIngester, PulsarJSONMessager[messages.Billing
             session.commit()
 
 
-class WorkspaceSettingsIngesterMessager(DBIngester, PulsarJSONMessager[messages.WorkspaceSettings]):
+class WorkspaceSettingsIngesterMessager(
+    DBIngester, PulsarJSONMessager[messages.WorkspaceSettings, bytes]
+):
     def process_payload(self, wsmsg: messages.WorkspaceSettings) -> Sequence[Messager.Action]:
         with Session(db.engine) as session:
             recorded = models.WorkspaceAccount.record_mapping(

--- a/accounting_service/ingester/messager.py
+++ b/accounting_service/ingester/messager.py
@@ -1,4 +1,6 @@
 import logging
+import uuid
+from datetime import datetime, timedelta
 from typing import Optional, Sequence
 from uuid import UUID
 
@@ -16,6 +18,11 @@ class DBIngester:
             return True
 
         return False
+
+    def _add_observed_sku(self, msg):
+        with Session(db.engine) as session:
+            session.add(models.BillingItem(sku=msg.sku, name="", unit=""))
+            session.commit()
 
 
 class AccountingIngesterMessager(DBIngester, PulsarJSONMessager[messages.BillingEvent, bytes]):
@@ -54,11 +61,6 @@ class AccountingIngesterMessager(DBIngester, PulsarJSONMessager[messages.Billing
 
         return uuid
 
-    def _add_observed_sku(self, bemsg: messages.BillingEvent):
-        with Session(db.engine) as session:
-            session.add(models.BillingItem(sku=bemsg.sku, name="", unit=""))
-            session.commit()
-
 
 class WorkspaceSettingsIngesterMessager(
     DBIngester, PulsarJSONMessager[messages.WorkspaceSettings, bytes]
@@ -76,3 +78,148 @@ class WorkspaceSettingsIngesterMessager(
             logging.debug("Ignoring WorkspaceSettings for %s, already known", wsmsg.name)
 
         return []
+
+
+class ConsumptionSampleRateIngesterMessager(
+    DBIngester, PulsarJSONMessager[messages.BillingResourceConsumptionRateSample, bytes]
+):
+    """
+    This Messager receives Pulsar messages containing consumption rate samples and adds them to
+    the accounting DB. It also converts them to estimated BillingEvents periodically.
+    """
+
+    def process_payload(
+        self, msg: messages.BillingResourceConsumptionRateSample
+    ) -> Sequence[Messager.Action]:
+        self._record_event(msg)
+
+        # We must convert previously recorded consumption rate data into billing events.
+        # We do this in one hour windows.
+        #
+        # To do this accurately, we need complete consumption rate data extending at least one
+        # sample beyoned the end of the window, so when we receive a message we generate up
+        # to the start of the hour containing its timestamp.
+        #
+        # If a resource is deleted then part of the last hour of use may be uncharged.
+        # To prevent this the relevant collector should listen for resource deletion events
+        # from Pulsar and generate zero rate messages at that timepoint and an hour later.
+        # None do this at present, but deletion is currently rare.
+        msg_datetime = datetime.fromisoformat(msg.sample_time)
+        generate_upto = msg_datetime.replace(minute=0, second=0, microsecond=0, tzinfo=None)
+        self._generate_new_estimates(msg.workspace, msg.sku, generate_upto)
+
+        return []
+
+    def _record_event(self, msg: messages.BillingResourceConsumptionRateSample):
+        try:
+            uuid = self._try_record_event(msg)
+        except IntegrityError:
+            logging.exception(
+                "IntegrityError recording %s with sku %s - assuming missing BillingItem",
+                type(msg),
+                msg.sku,
+            )
+
+            self._add_observed_sku(msg)
+            uuid = self._try_record_event(msg)
+
+        if uuid:
+            logging.debug("Recorded %s with uuid %s", type(msg), str(uuid))
+        else:
+            logging.info("Received duplicate %s uuid %s", type(msg), msg.uuid)
+
+    def _try_record_event(
+        self, msg: messages.BillingResourceConsumptionRateSample
+    ) -> Optional[UUID]:
+        with Session(db.engine) as session:
+            uuid = models.BillableResourceConsumptionRateSample.insert_from_message(session, msg)
+            session.commit()
+
+        return uuid
+
+    @staticmethod
+    def _generate_new_estimates(workspace, sku, upto):
+        """
+        This generates BillingEvents with estimated resource consumption for one hour windows, each
+        starting on the hour. The first will begin at the end time of the last generated
+        BillingItem for this SKU and workspace if any exists, otherwise it will begin at the start
+        of the hour in which the first observed consumption rate sample was taken.
+
+        The last will end at the start of the clock hour containing `upto`.
+        """
+        logging.debug(
+            "Generating BillingEvent estimates for workspace %s and sku %s up to %s",
+            workspace,
+            sku,
+            upto,
+        )
+
+        with Session(db.engine) as session:
+            item = models.BillingItem.find_billing_item(session, sku=sku)
+            assert item is not None  # _record_event would have failed without it
+
+            last_estimate = models.BillingEvent.find_latest_billing_event(session, workspace, sku)
+            logging.debug(
+                "Last estimated billing event for workspace %s and sku %s was %s",
+                workspace,
+                sku,
+                last_estimate,
+            )
+            if last_estimate:
+                # Continue estimating from after the last estimate.
+                generate_from = last_estimate.event_end
+            else:
+                # No prior estimates - estimate starting from when we first had consumption rate
+                # data.
+                earliest_sample = models.BillableResourceConsumptionRateSample.find_earliest(
+                    session, workspace, item.uuid
+                )
+                assert earliest_sample is not None
+
+                generate_from = earliest_sample.sample_time.replace(
+                    minute=0, second=0, microsecond=0
+                )
+
+            generate_to = (generate_from + timedelta(hours=1)).replace(
+                minute=0, second=0, microsecond=0
+            )
+
+            while generate_to <= upto:
+                logging.debug(
+                    "Generating BillingEvent estimates for workspace %s and sku %s for window %s to %s",
+                    workspace,
+                    sku,
+                    generate_from,
+                    generate_to,
+                )
+                consumption = (
+                    models.BillableResourceConsumptionRateSample.calculate_consumption_for_interval(
+                        session,
+                        workspace,
+                        sku,
+                        generate_from,
+                        generate_to,
+                    )
+                )
+
+                session.add(
+                    models.BillingEvent(
+                        uuid=uuid.uuid5(
+                            uuid.UUID("67f9a35c-567c-4a30-b51d-2fc64328bd55"),
+                            f"{workspace}-{sku}-{generate_from.isoformat()}",
+                        ),
+                        event_start=generate_from,
+                        event_end=generate_to,
+                        item=item,
+                        user=None,
+                        workspace=workspace,
+                        quantity=consumption,
+                    )
+                )
+
+                generate_from = generate_to
+                generate_to = (generate_from + timedelta(hours=1)).replace(
+                    minute=0, second=0, microsecond=0
+                )
+
+            session.commit()

--- a/accounting_service/ingester/messager.py
+++ b/accounting_service/ingester/messager.py
@@ -213,7 +213,7 @@ class ConsumptionSampleRateIngesterMessager(
                         item=item,
                         user=None,
                         workspace=workspace,
-                        quantity=consumption,
+                        quantity=consumption or 0,
                     )
                 )
 

--- a/accounting_service/ingester/messager.py
+++ b/accounting_service/ingester/messager.py
@@ -21,7 +21,7 @@ class DBIngester:
 
     def _add_observed_sku(self, msg):
         with Session(db.engine) as session:
-            session.add(models.BillingItem(sku=msg.sku, name="", unit=""))
+            models.BillingItem.ensure_sku_exists(session, msg.sku)
             session.commit()
 
 

--- a/accounting_service/ingester/messager.py
+++ b/accounting_service/ingester/messager.py
@@ -171,7 +171,7 @@ class ConsumptionSampleRateIngesterMessager(
             )
             if last_estimate:
                 # Continue estimating from after the last estimate.
-                generate_from = last_estimate.event_end
+                generate_from = last_estimate.event_end_utc
             else:
                 # No prior estimates - estimate starting from when we first had consumption rate
                 # data.

--- a/accounting_service/ingester/messager.py
+++ b/accounting_service/ingester/messager.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Sequence
 from uuid import UUID
 
@@ -104,8 +104,8 @@ class ConsumptionSampleRateIngesterMessager(
         # To prevent this the relevant collector should listen for resource deletion events
         # from Pulsar and generate zero rate messages at that timepoint and an hour later.
         # None do this at present, but deletion is currently rare.
-        msg_datetime = datetime.fromisoformat(msg.sample_time)
-        generate_upto = msg_datetime.replace(minute=0, second=0, microsecond=0, tzinfo=None)
+        msg_datetime = datetime.fromisoformat(msg.sample_time).astimezone(timezone.utc)
+        generate_upto = msg_datetime.replace(minute=0, second=0, microsecond=0)
         self._generate_new_estimates(msg.workspace, msg.sku, generate_upto)
 
         return []

--- a/accounting_service/models.py
+++ b/accounting_service/models.py
@@ -295,7 +295,7 @@ class BillingEvent(Base):
         if sku is not None:
             query = query.join(BillingItem).where(BillingItem.sku == sku)
 
-        return session.execute(query).one_or_none()
+        return session.execute(query).scalar_one_or_none()
 
     @classmethod
     def insert_from_message(

--- a/accounting_service/models.py
+++ b/accounting_service/models.py
@@ -102,6 +102,26 @@ class BillingItem(Base):
         result = session.execute(query).first()
         return result[0] if result else None
 
+    @classmethod
+    def ensure_sku_exists(cls, session: Session, sku: str) -> Optional[Self]:
+        """
+        This creates a stub BillingItem for an SKU if none already exists.
+        """
+        session.execute(
+            text(
+                "INSERT INTO billing_item (uuid, sku, name, unit) "
+                + "SELECT gen_random_uuid(), cast(:sku as text), '', '' "
+                + "WHERE NOT EXISTS ("
+                + "    SELECT 1 FROM billing_item "
+                + "    WHERE sku=:sku)"
+            ),
+            [
+                {
+                    "sku": sku,
+                }
+            ],
+        )
+
 
 class BillingItemPrice(Base):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
   "pydantic-settings",
   "click",
   "opentelemetry-instrumentation-fastapi",
-  "eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.7",
+  "eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@EODHP-906-consumption-rate-messages",
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
   "pydantic-settings",
   "click",
   "opentelemetry-instrumentation-fastapi",
-  "eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@EODHP-906-consumption-rate-messages",
+  "eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.8",
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -53,7 +53,7 @@ dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
     # via fastapi
-eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@EODHP-906-consumption-rate-messages
+eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.8
     # via accounting-service (pyproject.toml)
 execnet==2.1.1
     # via pytest-xdist
@@ -236,7 +236,7 @@ rpds-py==0.24.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.11.5
+ruff==0.11.6
     # via accounting-service (pyproject.toml)
 s3transfer==0.11.4
     # via boto3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,9 +19,9 @@ attrs==25.3.0
     #   referencing
 black==25.1.0
     # via accounting-service (pyproject.toml)
-boto3==1.37.30
+boto3==1.37.35
     # via eodhp-utils
-botocore==1.37.30
+botocore==1.37.35
     # via
     #   boto3
     #   eodhp-utils
@@ -53,7 +53,7 @@ dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
     # via fastapi
-eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.7
+eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@EODHP-906-consumption-rate-messages
     # via accounting-service (pyproject.toml)
 execnet==2.1.1
     # via pytest-xdist
@@ -69,13 +69,13 @@ fastjsonschema==2.21.1
     # via validate-pyproject
 filelock==3.18.0
     # via virtualenv
-greenlet==3.1.1
+greenlet==3.2.0
     # via sqlalchemy
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.7
+httpcore==1.0.8
     # via httpx
 httptools==0.6.4
     # via uvicorn
@@ -116,7 +116,7 @@ mypy-extensions==1.0.0
     # via black
 nodeenv==1.9.1
     # via pre-commit
-opentelemetry-api==1.31.1
+opentelemetry-api==1.32.1
     # via
     #   eodhp-utils
     #   opentelemetry-instrumentation
@@ -126,30 +126,30 @@ opentelemetry-api==1.31.1
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.52b1
+opentelemetry-instrumentation==0.53b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-logging
-opentelemetry-instrumentation-asgi==0.52b1
+opentelemetry-instrumentation-asgi==0.53b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-fastapi==0.52b1
+opentelemetry-instrumentation-fastapi==0.53b1
     # via accounting-service (pyproject.toml)
-opentelemetry-instrumentation-logging==0.52b1
+opentelemetry-instrumentation-logging==0.53b1
     # via eodhp-utils
-opentelemetry-processor-baggage==0.52b1
+opentelemetry-processor-baggage==0.53b1
     # via eodhp-utils
-opentelemetry-sdk==1.31.1
+opentelemetry-sdk==1.32.1
     # via
     #   eodhp-utils
     #   opentelemetry-processor-baggage
-opentelemetry-semantic-conventions==0.52b1
+opentelemetry-semantic-conventions==0.53b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.52b1
+opentelemetry-util-http==0.53b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -236,7 +236,7 @@ rpds-py==0.24.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.11.4
+ruff==0.11.5
     # via accounting-service (pyproject.toml)
 s3transfer==0.11.4
     # via boto3
@@ -248,13 +248,13 @@ sniffio==1.3.1
     # via anyio
 sqlalchemy==2.0.40
     # via accounting-service (pyproject.toml)
-starlette==0.46.1
+starlette==0.46.2
     # via fastapi
-trove-classifiers==2025.3.19.19
+trove-classifiers==2025.4.11.15
     # via validate-pyproject
 typer==0.15.2
     # via fastapi-cli
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   fastapi
     #   opentelemetry-sdk
@@ -269,9 +269,9 @@ typing-inspection==0.4.0
     # via pydantic
 tzdata==2025.2
     # via faker
-urllib3==2.3.0
+urllib3==2.4.0
     # via botocore
-uvicorn[standard]==0.34.0
+uvicorn[standard]==0.34.1
     # via
     #   fastapi
     #   fastapi-cli

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,9 +17,9 @@ attrs==25.3.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.37.30
+boto3==1.37.35
     # via eodhp-utils
-botocore==1.37.30
+botocore==1.37.35
     # via
     #   boto3
     #   eodhp-utils
@@ -43,7 +43,7 @@ dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
     # via fastapi
-eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.7
+eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@EODHP-906-consumption-rate-messages
     # via accounting-service (pyproject.toml)
 faker==37.1.0
     # via eodhp-utils
@@ -51,13 +51,13 @@ fastapi[standard]==0.115.12
     # via accounting-service (pyproject.toml)
 fastapi-cli[standard]==0.0.7
     # via fastapi
-greenlet==3.1.1
+greenlet==3.2.0
     # via sqlalchemy
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.7
+httpcore==1.0.8
     # via httpx
 httptools==0.6.4
     # via uvicorn
@@ -86,7 +86,7 @@ markupsafe==3.0.2
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-opentelemetry-api==1.31.1
+opentelemetry-api==1.32.1
     # via
     #   eodhp-utils
     #   opentelemetry-instrumentation
@@ -96,30 +96,30 @@ opentelemetry-api==1.31.1
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.52b1
+opentelemetry-instrumentation==0.53b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-logging
-opentelemetry-instrumentation-asgi==0.52b1
+opentelemetry-instrumentation-asgi==0.53b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-fastapi==0.52b1
+opentelemetry-instrumentation-fastapi==0.53b1
     # via accounting-service (pyproject.toml)
-opentelemetry-instrumentation-logging==0.52b1
+opentelemetry-instrumentation-logging==0.53b1
     # via eodhp-utils
-opentelemetry-processor-baggage==0.52b1
+opentelemetry-processor-baggage==0.53b1
     # via eodhp-utils
-opentelemetry-sdk==1.31.1
+opentelemetry-sdk==1.32.1
     # via
     #   eodhp-utils
     #   opentelemetry-processor-baggage
-opentelemetry-semantic-conventions==0.52b1
+opentelemetry-semantic-conventions==0.53b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.52b1
+opentelemetry-util-http==0.53b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -182,11 +182,11 @@ sniffio==1.3.1
     # via anyio
 sqlalchemy==2.0.40
     # via accounting-service (pyproject.toml)
-starlette==0.46.1
+starlette==0.46.2
     # via fastapi
 typer==0.15.2
     # via fastapi-cli
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   fastapi
     #   opentelemetry-sdk
@@ -201,9 +201,9 @@ typing-inspection==0.4.0
     # via pydantic
 tzdata==2025.2
     # via faker
-urllib3==2.3.0
+urllib3==2.4.0
     # via botocore
-uvicorn[standard]==0.34.0
+uvicorn[standard]==0.34.1
     # via
     #   fastapi
     #   fastapi-cli

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
     # via fastapi
-eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@EODHP-906-consumption-rate-messages
+eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.8
     # via accounting-service (pyproject.toml)
 faker==37.1.0
     # via eodhp-utils

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from datetime import timezone
 from typing import Type
 from unittest.mock import Mock
 
@@ -41,7 +42,7 @@ def fake_event_known_times():
     ############# Setup
     bemsg: messages.BillingEvent = messages.BillingEvent.get_fake()
 
-    start = faker.past_datetime("-30d")
+    start = faker.past_datetime("-30d", tzinfo=timezone.utc)
     end = start + faker.time_delta("+10m")
     bemsg.event_start = start.isoformat()
     bemsg.event_end = end.isoformat()

--- a/tests/test_consumption_rate_sample_processing.py
+++ b/tests/test_consumption_rate_sample_processing.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+from uuid import UUID
+
+from eodhp_utils.pulsar import messages
+from sqlalchemy.orm.session import Session
+
+from accounting_service import models
+from accounting_service.ingester.messager import ConsumptionSampleRateIngesterMessager
+from tests.conftest import msg_to_pulsar_msg
+
+
+def test_message_results_in_sample_in_db(db_session: Session):
+    ############# Setup
+    crs = messages.BillingResourceConsumptionRateSample.get_fake()
+    msg = msg_to_pulsar_msg(ConsumptionSampleRateIngesterMessager, crs)
+
+    db_session.add(models.BillingItem(sku=crs.sku, name="test", unit="GB-h"))
+    db_session.flush()
+    db_session.commit()
+
+    ############# Test
+    messager = ConsumptionSampleRateIngesterMessager()
+    failures = messager.consume(msg)
+
+    ############# Behaviour check
+    assert not failures.any_permanent()
+    assert not failures.any_temporary()
+
+    obj = db_session.get(models.BillableResourceConsumptionRateSample, UUID(crs.uuid))
+    assert str(obj.uuid) == crs.uuid
+    assert obj.sample_time == datetime.fromisoformat(crs.sample_time)
+    assert str(obj.user) == crs.user
+    assert obj.workspace == crs.workspace
+    assert obj.rate == crs.rate
+    assert obj.item.sku == crs.sku
+
+
+def test_messages_across_two_hours_generates_appropriate_billing_events(db_session: Session):
+    ############# Setup
+
+    crs1 = messages.BillingResourceConsumptionRateSample.get_fake(
+        sample_time="2025-01-01T01:30:00Z", rate=2
+    )
+    crs2 = messages.BillingResourceConsumptionRateSample.get_fake(
+        sample_time="2025-01-01T03:30:00Z", rate=4, sku=crs1.sku, workspace=crs1.workspace
+    )
+
+    db_session.add(models.BillingItem(sku=crs1.sku, name="test", unit="GB-h"))
+    db_session.flush()
+    db_session.commit()
+
+    msg1 = msg_to_pulsar_msg(ConsumptionSampleRateIngesterMessager, crs1)
+    msg2 = msg_to_pulsar_msg(ConsumptionSampleRateIngesterMessager, crs2)
+
+    ############# Test
+    messager = ConsumptionSampleRateIngesterMessager()
+    failures1 = messager.consume(msg1)
+    failures2 = messager.consume(msg2)
+
+    ############# Behaviour check
+    assert not failures1.any_permanent()
+    assert not failures1.any_temporary()
+    assert not failures2.any_permanent()
+    assert not failures2.any_temporary()
+
+    bes = list(models.BillingEvent.find_billing_events(db_session, crs1.workspace))
+    assert len(bes) == 2
+
+    assert bes[0].event_start == datetime(2025, 1, 1, 1, 0, 0)
+    assert bes[0].event_end == datetime(2025, 1, 1, 2, 0, 0)
+    assert bes[1].event_start == datetime(2025, 1, 1, 2, 0, 0)
+    assert bes[1].event_end == datetime(2025, 1, 1, 3, 0, 0)
+
+    assert bes[0].item.sku == crs1.sku
+    assert bes[1].item.sku == crs1.sku
+
+    assert bes[0].workspace == crs1.workspace
+    assert bes[1].workspace == crs1.workspace
+
+    # Interpolated/known consumption rates are:
+    #  01:00:00: 0
+    #  01:30:00: 2
+    #  02:00:00: 2.5 (interpolated)
+    #  03:00:00: 3.5 (interpolated)
+    #  03:30:00: 4
+    assert bes[0].quantity == 1800 * (2 + 2.5) / 2
+    assert bes[1].quantity == 3600 * (2.5 + 3.5) / 2

--- a/tests/test_consumption_rate_sample_processing.py
+++ b/tests/test_consumption_rate_sample_processing.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 from eodhp_utils.pulsar import messages
@@ -66,10 +66,10 @@ def test_messages_across_two_hours_generates_appropriate_billing_events(db_sessi
     bes = list(models.BillingEvent.find_billing_events(db_session, crs1.workspace))
     assert len(bes) == 2
 
-    assert bes[0].event_start == datetime(2025, 1, 1, 1, 0, 0)
-    assert bes[0].event_end == datetime(2025, 1, 1, 2, 0, 0)
-    assert bes[1].event_start == datetime(2025, 1, 1, 2, 0, 0)
-    assert bes[1].event_end == datetime(2025, 1, 1, 3, 0, 0)
+    assert bes[0].event_start == datetime(2025, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
+    assert bes[0].event_end == datetime(2025, 1, 1, 2, 0, 0, tzinfo=timezone.utc)
+    assert bes[1].event_start == datetime(2025, 1, 1, 2, 0, 0, tzinfo=timezone.utc)
+    assert bes[1].event_end == datetime(2025, 1, 1, 3, 0, 0, tzinfo=timezone.utc)
 
     assert bes[0].item.sku == crs1.sku
     assert bes[1].item.sku == crs1.sku

--- a/tests/test_consumption_rate_sample_processing.py
+++ b/tests/test_consumption_rate_sample_processing.py
@@ -28,7 +28,7 @@ def test_message_results_in_sample_in_db(db_session: Session):
 
     obj = db_session.get(models.BillableResourceConsumptionRateSample, UUID(crs.uuid))
     assert str(obj.uuid) == crs.uuid
-    assert obj.sample_time == datetime.fromisoformat(crs.sample_time)
+    assert obj.sample_time_utc == datetime.fromisoformat(crs.sample_time)
     assert str(obj.user) == crs.user
     assert obj.workspace == crs.workspace
     assert obj.rate == crs.rate
@@ -66,10 +66,10 @@ def test_messages_across_two_hours_generates_appropriate_billing_events(db_sessi
     bes = list(models.BillingEvent.find_billing_events(db_session, crs1.workspace))
     assert len(bes) == 2
 
-    assert bes[0].event_start == datetime(2025, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
-    assert bes[0].event_end == datetime(2025, 1, 1, 2, 0, 0, tzinfo=timezone.utc)
-    assert bes[1].event_start == datetime(2025, 1, 1, 2, 0, 0, tzinfo=timezone.utc)
-    assert bes[1].event_end == datetime(2025, 1, 1, 3, 0, 0, tzinfo=timezone.utc)
+    assert bes[0].event_start_utc == datetime(2025, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
+    assert bes[0].event_end_utc == datetime(2025, 1, 1, 2, 0, 0, tzinfo=timezone.utc)
+    assert bes[1].event_start_utc == datetime(2025, 1, 1, 2, 0, 0, tzinfo=timezone.utc)
+    assert bes[1].event_end_utc == datetime(2025, 1, 1, 3, 0, 0, tzinfo=timezone.utc)
 
     assert bes[0].item.sku == crs1.sku
     assert bes[1].item.sku == crs1.sku

--- a/tests/test_messager.py
+++ b/tests/test_messager.py
@@ -34,8 +34,9 @@ def test_message_results_in_billingevent_in_db(db_session: Session):
 
     beobj = db_session.get(models.BillingEvent, UUID(bemsg.uuid))
     assert str(beobj.uuid) == bemsg.uuid
-    assert beobj.event_start == start
-    assert beobj.event_end == end
+
+    assert beobj.event_start_utc == start
+    assert beobj.event_end_utc == end
     assert str(beobj.user) == bemsg.user
     assert beobj.workspace == bemsg.workspace
     assert beobj.quantity == bemsg.quantity

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional, Sequence
 
 import pytest
@@ -82,7 +82,7 @@ def gen_billingitem_data(
     for event in events:
         event_uuid = uuid.uuid4()
 
-        start = event.get("event_start", fake.past_datetime("-30d"))
+        start = event.get("event_start", fake.past_datetime("-30d", tzinfo=timezone.utc))
         end = event.get("event_end", start + timedelta(minutes=5))
 
         item_sku = event.get("sku", "testsku")
@@ -144,12 +144,30 @@ def test_finding_billing_events_for_workspace(db_session: Session):
     event_uuids, account_uuids, item_uuids = gen_billingitem_data(
         db_session,
         [
-            {"workspace": "workspace1", "event_start": datetime(2024, 1, 16, 6, 10, 0)},
-            {"workspace": "workspace1", "event_start": datetime(2024, 1, 16, 7, 10, 0)},
-            {"workspace": "workspace1", "event_start": datetime(2024, 1, 16, 8, 10, 0)},
-            {"workspace": "workspace1", "event_start": datetime(2024, 1, 16, 9, 10, 0)},
-            {"workspace": "workspace2", "event_start": datetime(2024, 1, 16, 7, 5, 0)},
-            {"workspace": "workspace3", "event_start": datetime(2024, 1, 17, 7, 5, 0)},
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2024, 1, 16, 6, 10, 0, tzinfo=timezone.utc),
+            },
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2024, 1, 16, 7, 10, 0, tzinfo=timezone.utc),
+            },
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2024, 1, 16, 8, 10, 0, tzinfo=timezone.utc),
+            },
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2024, 1, 16, 9, 10, 0, tzinfo=timezone.utc),
+            },
+            {
+                "workspace": "workspace2",
+                "event_start": datetime(2024, 1, 16, 7, 5, 0, tzinfo=timezone.utc),
+            },
+            {
+                "workspace": "workspace3",
+                "event_start": datetime(2024, 1, 17, 7, 5, 0, tzinfo=timezone.utc),
+            },
         ],
     )
 
@@ -157,8 +175,8 @@ def test_finding_billing_events_for_workspace(db_session: Session):
     bes = models.BillingEvent.find_billing_events(
         db_session,
         workspace="workspace1",
-        start=datetime(2024, 1, 16, 7, 5, 0),
-        end=datetime(2024, 1, 16, 9, 5, 0),
+        start=datetime(2024, 1, 16, 7, 5, 0, tzinfo=timezone.utc),
+        end=datetime(2024, 1, 16, 9, 5, 0, tzinfo=timezone.utc),
     )
 
     ############# Behaviour check
@@ -177,11 +195,26 @@ def test_paging_billing_events_produces_all_events_once(db_session: Session):
     event_uuids, account_uuids, item_uuids = gen_billingitem_data(
         db_session,
         [
-            {"workspace": "workspace1", "event_start": datetime(2024, 1, 16, 6, 10, 0)},
-            {"workspace": "workspace2", "event_start": datetime(2024, 1, 16, 7, 5, 0)},
-            {"workspace": "workspace3", "event_start": datetime(2024, 1, 16, 7, 5, 0)},
-            {"workspace": "workspace1", "event_start": datetime(2024, 1, 16, 7, 10, 0)},
-            {"workspace": "workspace1", "event_start": datetime(2024, 1, 16, 8, 10, 0)},
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2024, 1, 16, 6, 10, 0, tzinfo=timezone.utc),
+            },
+            {
+                "workspace": "workspace2",
+                "event_start": datetime(2024, 1, 16, 7, 5, 0, tzinfo=timezone.utc),
+            },
+            {
+                "workspace": "workspace3",
+                "event_start": datetime(2024, 1, 16, 7, 5, 0, tzinfo=timezone.utc),
+            },
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2024, 1, 16, 7, 10, 0, tzinfo=timezone.utc),
+            },
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2024, 1, 16, 8, 10, 0, tzinfo=timezone.utc),
+            },
         ],
     )
 
@@ -210,55 +243,55 @@ def fake_rate_samples(db_session):
     db_session.add(models.BillingItem(sku="nottestsku", name="test", unit="GB-h"))
     return [
         messages.BillingResourceConsumptionRateSample.get_fake(
-            sample_time="2025-01-01T00:45:00",
+            sample_time="2025-01-01T00:45:00Z",
             workspace="workspace1",
             rate=1,
             sku="testsku",
         ),
         messages.BillingResourceConsumptionRateSample.get_fake(
-            sample_time="2025-01-01T00:55:00",
+            sample_time="2025-01-01T00:55:00Z",
             workspace="workspace1",
             rate=2,
             sku="testsku",
         ),
         messages.BillingResourceConsumptionRateSample.get_fake(
-            sample_time="2025-01-01T01:15:00",
+            sample_time="2025-01-01T01:15:00Z",
             workspace="workspace1",
             rate=3,
             sku="testsku",
         ),
         messages.BillingResourceConsumptionRateSample.get_fake(
-            sample_time="2025-01-01T01:25:00",
+            sample_time="2025-01-01T01:25:00Z",
             workspace="workspace1",
             rate=4,
             sku="testsku",
         ),
         messages.BillingResourceConsumptionRateSample.get_fake(
-            sample_time="2025-01-01T01:50:00",
+            sample_time="2025-01-01T01:50:00Z",
             workspace="workspace1",
             rate=2,
             sku="testsku",
         ),
         messages.BillingResourceConsumptionRateSample.get_fake(
-            sample_time="2025-01-01T02:05:00",
+            sample_time="2025-01-01T02:05:00Z",
             workspace="workspace1",
             rate=1,
             sku="testsku",
         ),
         messages.BillingResourceConsumptionRateSample.get_fake(
-            sample_time="2025-01-01T02:55:00",
+            sample_time="2025-01-01T02:55:00Z",
             workspace="workspace1",
             rate=90,
             sku="testsku",
         ),
         messages.BillingResourceConsumptionRateSample.get_fake(
-            sample_time="2025-01-01T01:35:00",
+            sample_time="2025-01-01T01:35:00Z",
             workspace="workspace2",
             rate=900,
             sku="testsku",
         ),
         messages.BillingResourceConsumptionRateSample.get_fake(
-            sample_time="2025-01-01T01:35:00",
+            sample_time="2025-01-01T01:35:00Z",
             workspace="workspace1",
             rate=900,
             sku="nottestsku",
@@ -301,8 +334,8 @@ def test_round_trip_billingresourceconsumptionratesample_insertfrommessage_retri
             db_session,
             "workspace1",
             "testsku",
-            datetime(2025, 1, 1, 1, 0, 0),
-            datetime(2025, 1, 1, 2, 0, 0),
+            datetime(2025, 1, 1, 1, 0, 0, tzinfo=timezone.utc),
+            datetime(2025, 1, 1, 2, 0, 0, tzinfo=timezone.utc),
         )
     )
 
@@ -325,7 +358,11 @@ def test_round_trip_billingresourceconsumptionratesample_insertfrommessage_retri
         #   * 1:15: 3 (exact start)
         #   * 1:25: 4 (exact end)
         # Consumption estimate is (3+4)/2 * 600
-        pytest.param(datetime(2025, 1, 1, 1, 15, 0), datetime(2025, 1, 1, 1, 25, 0), 3.5 * 600),
+        pytest.param(
+            datetime(2025, 1, 1, 1, 15, 0, tzinfo=timezone.utc),
+            datetime(2025, 1, 1, 1, 25, 0, tzinfo=timezone.utc),
+            3.5 * 600,
+        ),
         # Samples for this 1h window should be:
         #   * 1:00: 2.25 (interpolated between 2 and 3)
         #   * 1:15: 3
@@ -334,14 +371,22 @@ def test_round_trip_billingresourceconsumptionratesample_insertfrommessage_retri
         #   * 2:00: 1.3333 (interpolated between 2 and 1)
         # Consumption estimate is 900*(2.25+3)/2 + 600*(3+4)/2 + 1500*(4+2)/2 + 600*(2+1.3333)/2
         #  = 9962.5
-        pytest.param(datetime(2025, 1, 1, 1, 0, 0), datetime(2025, 1, 1, 2, 0, 0), 9962.5),
+        pytest.param(
+            datetime(2025, 1, 1, 1, 0, 0, tzinfo=timezone.utc),
+            datetime(2025, 1, 1, 2, 0, 0, tzinfo=timezone.utc),
+            9962.5,
+        ),
         # Samples for this 2 min window should be:
         #   * 1:15: 3 (before window)
         #   * 1:19: 3.4 (interpolated window start)
         #   * 1:21: 3.6 (interpolated window end)
         #   * 1:25: 4 (after window)
         # Consumption estimate is 120 * (3.6+3.4)/2
-        pytest.param(datetime(2025, 1, 1, 1, 19, 0), datetime(2025, 1, 1, 1, 21, 0), 420.0),
+        pytest.param(
+            datetime(2025, 1, 1, 1, 19, 0, tzinfo=timezone.utc),
+            datetime(2025, 1, 1, 1, 21, 0, tzinfo=timezone.utc),
+            420.0,
+        ),
         # Samples for this 50m window should be:
         #   * 0:00: No samples
         #   * 0:45: 1
@@ -350,7 +395,11 @@ def test_round_trip_billingresourceconsumptionratesample_insertfrommessage_retri
         #
         # Consumption estimate is 300*(1+1.5)/2 = 375
         # Note: counted as zero up to first sample
-        pytest.param(datetime(2025, 1, 1, 0, 0, 0), datetime(2025, 1, 1, 0, 50, 0), 375),
+        pytest.param(
+            datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(2025, 1, 1, 0, 50, 0, tzinfo=timezone.utc),
+            375,
+        ),
         # Samples for this 1h window should be:
         #   * 2:05: 1 (before window)
         #   * 2:30: 45.5 (interpolated)
@@ -359,7 +408,11 @@ def test_round_trip_billingresourceconsumptionratesample_insertfrommessage_retri
         #   * 3:30: 0 (window end)
         #   * no later samples
         # Consumption estimate is 25*60*(45.5+90)/2 = 101625.0
-        pytest.param(datetime(2025, 1, 1, 2, 30, 0), datetime(2025, 1, 1, 3, 30, 0), 101625.0),
+        pytest.param(
+            datetime(2025, 1, 1, 2, 30, 0, tzinfo=timezone.utc),
+            datetime(2025, 1, 1, 3, 30, 0, tzinfo=timezone.utc),
+            101625.0,
+        ),
     ],
 )
 def test_consumption_estimation_from_billingresourceconsumptionratesamples(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,8 +23,8 @@ def test_round_trip_billingevent_insertfrommessage_retrieve(db_session: Session)
     ############# Behaviour check
     beobj = db_session.get(models.BillingEvent, beuuid)
     assert str(beobj.uuid) == bemsg.uuid
-    assert beobj.event_start == start
-    assert beobj.event_end == end
+    assert beobj.event_start_utc == start
+    assert beobj.event_end_utc == end
     assert str(beobj.user) == bemsg.user
     assert beobj.workspace == bemsg.workspace
     assert beobj.quantity == bemsg.quantity
@@ -312,7 +312,7 @@ def test_round_trip_billingresourceconsumptionratesample_insertfrommessage_retri
     ############# Behaviour check
     brobj = db_session.get(models.BillableResourceConsumptionRateSample, bruuid)
     assert str(brobj.uuid) == msg.uuid
-    assert brobj.sample_time.isoformat() == msg.sample_time
+    assert brobj.sample_time_utc.isoformat() == msg.sample_time
     assert str(brobj.user) == msg.user
     assert brobj.workspace == msg.workspace
     assert brobj.rate == msg.rate

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,8 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Sequence
 
+import pytest
+from eodhp_utils.pulsar import messages
 from faker import Faker
 from sqlalchemy import delete
 from sqlalchemy.orm.session import Session
@@ -200,3 +202,179 @@ def test_paging_billing_events_produces_all_events_once(db_session: Session):
 
     assert len(bes3) == 1
     assert bes3[0].uuid == event_uuids[4]
+
+
+@pytest.fixture
+def fake_rate_samples(db_session):
+    db_session.add(models.BillingItem(sku="testsku", name="test", unit="GB-h"))
+    db_session.add(models.BillingItem(sku="nottestsku", name="test", unit="GB-h"))
+    return [
+        messages.BillingResourceConsumptionRateSample.get_fake(
+            sample_time="2025-01-01T00:45:00",
+            workspace="workspace1",
+            rate=1,
+            sku="testsku",
+        ),
+        messages.BillingResourceConsumptionRateSample.get_fake(
+            sample_time="2025-01-01T00:55:00",
+            workspace="workspace1",
+            rate=2,
+            sku="testsku",
+        ),
+        messages.BillingResourceConsumptionRateSample.get_fake(
+            sample_time="2025-01-01T01:15:00",
+            workspace="workspace1",
+            rate=3,
+            sku="testsku",
+        ),
+        messages.BillingResourceConsumptionRateSample.get_fake(
+            sample_time="2025-01-01T01:25:00",
+            workspace="workspace1",
+            rate=4,
+            sku="testsku",
+        ),
+        messages.BillingResourceConsumptionRateSample.get_fake(
+            sample_time="2025-01-01T01:50:00",
+            workspace="workspace1",
+            rate=2,
+            sku="testsku",
+        ),
+        messages.BillingResourceConsumptionRateSample.get_fake(
+            sample_time="2025-01-01T02:05:00",
+            workspace="workspace1",
+            rate=1,
+            sku="testsku",
+        ),
+        messages.BillingResourceConsumptionRateSample.get_fake(
+            sample_time="2025-01-01T02:55:00",
+            workspace="workspace1",
+            rate=90,
+            sku="testsku",
+        ),
+        messages.BillingResourceConsumptionRateSample.get_fake(
+            sample_time="2025-01-01T01:35:00",
+            workspace="workspace2",
+            rate=900,
+            sku="testsku",
+        ),
+        messages.BillingResourceConsumptionRateSample.get_fake(
+            sample_time="2025-01-01T01:35:00",
+            workspace="workspace1",
+            rate=900,
+            sku="nottestsku",
+        ),
+    ]
+
+
+def test_round_trip_billingresourceconsumptionratesample_insertfrommessage_retrieve(
+    db_session: Session,
+):
+    ############# Setup
+    msg = messages.BillingResourceConsumptionRateSample.get_fake()
+    db_session.add(models.BillingItem(sku=msg.sku, name="test", unit="GB-h"))
+
+    ############# Test
+    bruuid = models.BillableResourceConsumptionRateSample.insert_from_message(db_session, msg)
+
+    ############# Behaviour check
+    brobj = db_session.get(models.BillableResourceConsumptionRateSample, bruuid)
+    assert str(brobj.uuid) == msg.uuid
+    assert brobj.sample_time.isoformat() == msg.sample_time
+    assert str(brobj.user) == msg.user
+    assert brobj.workspace == msg.workspace
+    assert brobj.rate == msg.rate
+    assert brobj.item.sku == msg.sku
+
+
+def test_round_trip_billingresourceconsumptionratesample_insertfrommessage_retrieve_interval(
+    db_session: Session, fake_rate_samples
+):
+    ############# Setup
+    # This creates several samples around our window of interest, 1am-2am 2025-01-01, to send to
+    # the data store.
+    for sample in fake_rate_samples:
+        models.BillableResourceConsumptionRateSample.insert_from_message(db_session, sample)
+
+    ############# Test
+    found_samples = list(
+        models.BillableResourceConsumptionRateSample.find_data_for_interval(
+            db_session,
+            "workspace1",
+            "testsku",
+            datetime(2025, 1, 1, 1, 0, 0),
+            datetime(2025, 1, 1, 2, 0, 0),
+        )
+    )
+
+    ############# Behaviour check
+    # The data found should be the last sample before, the last sample after and all samples during
+    # the test period.
+    assert len(found_samples) == 5
+
+    assert found_samples[0].rate == 2
+    assert found_samples[1].rate == 3
+    assert found_samples[2].rate == 4
+    assert found_samples[3].rate == 2
+    assert found_samples[4].rate == 1
+
+
+@pytest.mark.parametrize(
+    "start,end,expected_consumption",
+    [
+        # Samples for this 10 min window should be:
+        #   * 1:15: 3 (exact start)
+        #   * 1:25: 4 (exact end)
+        # Consumption estimate is (3+4)/2 * 600
+        pytest.param(datetime(2025, 1, 1, 1, 15, 0), datetime(2025, 1, 1, 1, 25, 0), 3.5 * 600),
+        # Samples for this 1h window should be:
+        #   * 1:00: 2.25 (interpolated between 2 and 3)
+        #   * 1:15: 3
+        #   * 1:25: 4
+        #   * 1:50: 2
+        #   * 2:00: 1.3333 (interpolated between 2 and 1)
+        # Consumption estimate is 900*(2.25+3)/2 + 600*(3+4)/2 + 1500*(4+2)/2 + 600*(2+1.3333)/2
+        #  = 9962.5
+        pytest.param(datetime(2025, 1, 1, 1, 0, 0), datetime(2025, 1, 1, 2, 0, 0), 9962.5),
+        # Samples for this 2 min window should be:
+        #   * 1:15: 3 (before window)
+        #   * 1:19: 3.4 (interpolated window start)
+        #   * 1:21: 3.6 (interpolated window end)
+        #   * 1:25: 4 (after window)
+        # Consumption estimate is 120 * (3.6+3.4)/2
+        pytest.param(datetime(2025, 1, 1, 1, 19, 0), datetime(2025, 1, 1, 1, 21, 0), 420.0),
+        # Samples for this 50m window should be:
+        #   * 0:00: No samples
+        #   * 0:45: 1
+        #   * 0:50: 1.5 (interpolated at window end)
+        #   * 0:55: 2 (after window)
+        #
+        # Consumption estimate is 300*(1+1.5)/2 = 375
+        # Note: counted as zero up to first sample
+        pytest.param(datetime(2025, 1, 1, 0, 0, 0), datetime(2025, 1, 1, 0, 50, 0), 375),
+        # Samples for this 1h window should be:
+        #   * 2:05: 1 (before window)
+        #   * 2:30: 45.5 (interpolated)
+        #   * 2:55: 90
+        #   * 2:55: 0 (resource assumed destroyed - no later samples)
+        #   * 3:30: 0 (window end)
+        #   * no later samples
+        # Consumption estimate is 25*60*(45.5+90)/2 = 101625.0
+        pytest.param(datetime(2025, 1, 1, 2, 30, 0), datetime(2025, 1, 1, 3, 30, 0), 101625.0),
+    ],
+)
+def test_consumption_estimation_from_billingresourceconsumptionratesamples(
+    db_session: Session, fake_rate_samples, start, end, expected_consumption
+):
+    ############# Setup
+    # This creates several samples around our window of interest, 1am-2am 2025-01-01, to send to
+    # the data store.
+    for sample in fake_rate_samples:
+        models.BillableResourceConsumptionRateSample.insert_from_message(db_session, sample)
+
+    ############# Test
+    consumption = models.BillableResourceConsumptionRateSample.calculate_consumption_for_interval(
+        db_session, "workspace1", "testsku", start, end
+    )
+
+    ############# Behaviour check
+    assert consumption == expected_consumption


### PR DESCRIPTION
This adds the concept of a consumption rate sample to the accounting service. This is a point-in-time sample of how quickly a billable resource is being consumed from which we can estimate the amount actually consumed over some period.

This is intended for storage, where the billable resource is an amount measured in gigabyte-seconds. If we measure your workspace store at 8GB then this means you're using 8GB-s per second.

This change includes:

* The Messager which ingests and records consumption rate samples.
* Code in this Messager to generate BillingEvents from the rate samples periodically.
* A change to use datetimes with a timestamp attached everywhere so there's no ambiguity about which zone they're in. PostgreSQL is now using TIMESTAMPTZ columns (which doesn't actually record a timezone, just takes it into account when you give it one).
* When creating stub BillingItems for SKUs we've observed but not got in the DB, be more careful not to create two if two instances of the service are running.
