### PR TITLE
Remove the 'user' field from the API.

### DIFF
--- a/accounting_service/app/app.py
+++ b/accounting_service/app/app.py
@@ -73,15 +73,6 @@ class BillingEventAPIResult(BaseModel):
             examples=["0.42"],
         ),
     ]
-    user: Annotated[
-        UUID | None,
-        Field(
-            description=(
-                "User who triggered consumption. May be unset where there is no single user,"
-                + " such as for storage."
-            )
-        ),
-    ]
 
 
 def billingevent_to_api_object(event: BillingEvent):
@@ -92,7 +83,6 @@ def billingevent_to_api_object(event: BillingEvent):
         "item": event.item.sku,
         "workspace": event.workspace,
         "quantity": event.quantity,
-        "user": event.user,
     }
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -62,7 +62,6 @@ def test_workspace_usage_data_returns_correct_items_from_db(
                 "event_start": "2024-01-16T07:05:00Z",
                 "event_end": "2024-01-16T07:10:00Z",
                 "item": "sku2",
-                "user": str(uid),
                 "workspace": "workspace2",
                 "quantity": 1.23,
             }
@@ -181,7 +180,6 @@ def test_account_usage_data_returns_correct_items_from_db(db_session: Session, c
                 "event_start": "2024-01-16T06:10:00Z",
                 "event_end": "2024-01-16T06:15:00Z",
                 "item": "sku1",
-                "user": str(uid),
                 "workspace": "workspace1",
                 "quantity": 1.1,
             },
@@ -190,7 +188,6 @@ def test_account_usage_data_returns_correct_items_from_db(db_session: Session, c
                 "event_start": "2024-01-16T07:05:00Z",
                 "event_end": "2024-01-16T07:10:00Z",
                 "item": "sku3",
-                "user": str(uid),
                 "workspace": "workspace3",
                 "quantity": 1.1,
             },


### PR DESCRIPTION
The 'user' field in accounting API responses was always null because nothing generates this data. This may confuse users so I've removed it from the API responses.