### PR TITLE
Aggregate by day

### DIFF
--- a/accounting_service/app/app.py
+++ b/accounting_service/app/app.py
@@ -362,6 +362,17 @@ def get_account_usage_data(
             examples=["456e15d1-d01b-4060-8b7b-85b93ecbf050"],
         ),
     ] = None,
+    time_aggregation: Annotated[
+        Optional[str],
+        Query(
+            title="Time aggregation of results",
+            description=(
+                "Optionally ggregate usage information into totals for the given time periods - "
+                + "'day' or 'month'"
+            ),
+            examples=["day", "month"],
+        ),
+    ] = None,
 ):
     """
     This returns resource consumption data for all workspaces billed to a specified account an
@@ -383,7 +394,13 @@ def get_account_usage_data(
     end = datetime_default_to_utc(end)
 
     events: Iterator[BillingEvent] = BillingEvent.find_billing_events(
-        session, account=account_id, start=start, end=end, limit=limit or 100, after=after
+        session,
+        account=account_id,
+        start=start,
+        end=end,
+        limit=limit or 100,
+        after=after,
+        time_aggregation=time_aggregation,
     )
 
     add_usage_data_headers(response)

--- a/accounting_service/app/app.py
+++ b/accounting_service/app/app.py
@@ -263,6 +263,7 @@ def get_workspace_usage_data(
     time_aggregation: Annotated[
         Optional[str],
         Query(
+            alias="time-aggregation",
             title="Time aggregation of results",
             description=(
                 "Optionally ggregate usage information into totals for the given time periods - "
@@ -365,6 +366,7 @@ def get_account_usage_data(
     time_aggregation: Annotated[
         Optional[str],
         Query(
+            alias="time-aggregation",
             title="Time aggregation of results",
             description=(
                 "Optionally ggregate usage information into totals for the given time periods - "

--- a/accounting_service/app/app.py
+++ b/accounting_service/app/app.py
@@ -260,6 +260,17 @@ def get_workspace_usage_data(
             examples=["456e15d1-d01b-4060-8b7b-85b93ecbf050"],
         ),
     ] = None,
+    time_aggregation: Annotated[
+        Optional[str],
+        Query(
+            title="Time aggregation of results",
+            description=(
+                "Optionally ggregate usage information into totals for the given time periods - "
+                + "'day' or 'month'"
+            ),
+            examples=["day", "month"],
+        ),
+    ] = None,
 ):
     """
     This returns resource consumption data for a workspace within some given time range (or all).
@@ -280,7 +291,13 @@ def get_workspace_usage_data(
     end = datetime_default_to_utc(end)
 
     events: Iterator[BillingEvent] = BillingEvent.find_billing_events(
-        session, workspace=workspace, start=start, end=end, limit=limit or 100, after=after
+        session,
+        workspace=workspace,
+        start=start,
+        end=end,
+        limit=limit or 100,
+        after=after,
+        time_aggregation=time_aggregation,
     )
 
     add_usage_data_headers(response)

--- a/accounting_service/app/app.py
+++ b/accounting_service/app/app.py
@@ -268,7 +268,7 @@ def get_workspace_usage_data(
             alias="time-aggregation",
             title="Time aggregation of results",
             description=(
-                "Optionally ggregate usage information into totals for the given time periods - "
+                "Optionally aggregate usage information into totals for the given time periods - "
                 + "'day' or 'month'"
             ),
             examples=["day", "month"],

--- a/accounting_service/db.py
+++ b/accounting_service/db.py
@@ -1,47 +1,13 @@
 import logging
-from typing import Optional, TextIO
+from typing import TextIO
 
 import yaml
-from pydantic_settings import BaseSettings
-from sqlalchemy import URL, create_engine
+from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from yaml.error import YAMLError
 
 from accounting_service import models
-
-
-class Settings(BaseSettings):
-    SQL_DRIVER: str = "sqlite+pysqlite"
-    SQL_PORT: Optional[int] = None
-    SQL_PASSWORD: Optional[str] = None
-    SQL_USER: Optional[str] = None
-    SQL_DATABASE: str = "accounting"
-    SQL_HOST: Optional[str] = None
-    SQL_SCHEMA: str = "public"
-
-    class Config:
-        env_file = "./.env"
-
-
-settings = Settings()
-
-
-def get_db_url() -> URL:
-    return URL.create(
-        settings.SQL_DRIVER,
-        username=settings.SQL_USER,
-        password=settings.SQL_PASSWORD,
-        host=settings.SQL_HOST,
-        port=settings.SQL_PORT,
-        database=settings.SQL_DATABASE,
-        query={"options": f"-c search_path={settings.SQL_SCHEMA}"},
-    )
-
-
-if settings.SQL_DRIVER.startswith("sqlite"):
-    connect_args = {"check_same_thread": False}
-else:
-    connect_args = {}
+from accounting_service.db_settings import connect_args, get_db_url
 
 engine = create_engine(get_db_url(), connect_args=connect_args)
 

--- a/accounting_service/db_settings.py
+++ b/accounting_service/db_settings.py
@@ -1,0 +1,42 @@
+from typing import Optional
+
+from pydantic_settings import BaseSettings
+from sqlalchemy import URL
+
+
+class Settings(BaseSettings):
+    SQL_DRIVER: str = "sqlite+pysqlite"
+    SQL_PORT: Optional[int] = None
+    SQL_PASSWORD: Optional[str] = None
+    SQL_USER: Optional[str] = None
+    SQL_DATABASE: str = "accounting"
+    SQL_HOST: Optional[str] = None
+    SQL_SCHEMA: str = "public"
+
+    class Config:
+        env_file = "./.env"
+
+
+settings = Settings()
+
+
+def get_db_url() -> URL:
+    return URL.create(
+        settings.SQL_DRIVER,
+        username=settings.SQL_USER,
+        password=settings.SQL_PASSWORD,
+        host=settings.SQL_HOST,
+        port=settings.SQL_PORT,
+        database=settings.SQL_DATABASE,
+        query={"options": f"-c search_path={settings.SQL_SCHEMA}"},
+    )
+
+
+if settings.SQL_DRIVER.startswith("sqlite"):
+    connect_args = {"check_same_thread": False}
+else:
+    connect_args = {}
+
+
+def is_sqlite():
+    return settings.SQL_DRIVER.startswith("sqlite")

--- a/accounting_service/models.py
+++ b/accounting_service/models.py
@@ -361,13 +361,15 @@ class BillingEvent(Base):
                 period_end_expr = (
                     f"datetime(event_start, 'start of {time_aggregation}', '+1 {time_aggregation}')"
                 )
+                uuid_expr = "MAX(CAST(uuid AS TEXT))"
             else:
                 period_start_expr = f"date_trunc('{time_aggregation}', event_start)"
                 period_end_expr = f"{period_start_expr} + '1 {time_aggregation}'::interval"
+                uuid_expr = "CAST(MAX(CAST(uuid AS TEXT)) AS UUID)"
 
             select_aggregated_events = text(
                 f"""
-SELECT CAST(MAX(CAST(uuid AS TEXT)) AS UUID) as uuid,
+SELECT {uuid_expr} as uuid,
        {period_start_expr} AS event_start,
        {period_end_expr} AS event_end,
        item_id,

--- a/accounting_service/models.py
+++ b/accounting_service/models.py
@@ -435,6 +435,11 @@ GROUP BY uuid, event_start, event_end, item_id, workspace
             # but it works when billingevent_src is an alias rather than an ORM class.
             logging.info(f"{select(billingevent_src).where(billingevent_src.uuid == after)=}")
             logging.info(f"{after=}")
+            print(f"{after=}")
+            print(str(select(billingevent_src).where(billingevent_src.uuid == after)))
+
+            if isinstance(after, str):
+                after = UUID(after)
 
             after_be = session.execute(
                 select(billingevent_src).where(billingevent_src.uuid == after)

--- a/accounting_service/models.py
+++ b/accounting_service/models.py
@@ -431,8 +431,8 @@ GROUP BY uuid, event_start, event_end, item_id, workspace
             #   after_be = session.get(cls, after)
             # but it works when billingevent_src is an alias rather than an ORM class.
             after_be = session.execute(
-                select(billingevent_src).where(billingevent_src.uuid == after)
-            ).scalar_one()
+                select(billingevent_src).where(billingevent_src.uuid == str(after))
+            ).scalar_one_or_none()
 
             if after_be is not None:
                 query = query.where(

--- a/accounting_service/models.py
+++ b/accounting_service/models.py
@@ -433,12 +433,13 @@ GROUP BY uuid, event_start, event_end, item_id, workspace
             # This is equivalent to
             #   after_be = session.get(cls, after)
             # but it works when billingevent_src is an alias rather than an ORM class.
+            logging.info(f"{select(billingevent_src).where(billingevent_src.uuid == after)=}")
+            logging.info(f"{after=}")
+
             after_be = session.execute(
                 select(billingevent_src).where(billingevent_src.uuid == after)
             ).scalar_one_or_none()
 
-            logging.info(f"{select(billingevent_src).where(billingevent_src.uuid == after)=}")
-            logging.info(f"{after=}")
             if after_be is None:
                 raise ValueError(f"{after} not found")
 

--- a/accounting_service/models.py
+++ b/accounting_service/models.py
@@ -437,34 +437,38 @@ GROUP BY uuid, event_start, event_end, item_id, workspace
                 select(billingevent_src).where(billingevent_src.uuid == after)
             ).scalar_one_or_none()
 
-            if after_be is not None:
-                query = query.where(
-                    or_(
-                        (billingevent_src.event_start > after_be.event_start),
-                        and_(
-                            billingevent_src.event_start == after_be.event_start,
-                            billingevent_src.event_end > after_be.event_end,
-                        ),
-                        and_(
-                            billingevent_src.event_start == after_be.event_start,
-                            billingevent_src.event_end == after_be.event_end,
-                            billingevent_src.workspace > after_be.workspace,
-                        ),
-                        and_(
-                            billingevent_src.event_start == after_be.event_start,
-                            billingevent_src.event_end == after_be.event_end,
-                            billingevent_src.workspace == after_be.workspace,
-                            BillingItem.sku > after_be.item.sku,
-                        ),
-                        and_(
-                            billingevent_src.event_start == after_be.event_start,
-                            billingevent_src.event_end == after_be.event_end,
-                            billingevent_src.workspace == after_be.workspace,
-                            BillingItem.sku == after_be.item.sku,
-                            billingevent_src.uuid > after,
-                        ),
-                    )
+            logging.info(f"{select(billingevent_src).where(billingevent_src.uuid == after)=}")
+            logging.info(f"{after=}")
+            if after_be is None:
+                raise ValueError(f"{after} not found")
+
+            query = query.where(
+                or_(
+                    (billingevent_src.event_start > after_be.event_start),
+                    and_(
+                        billingevent_src.event_start == after_be.event_start,
+                        billingevent_src.event_end > after_be.event_end,
+                    ),
+                    and_(
+                        billingevent_src.event_start == after_be.event_start,
+                        billingevent_src.event_end == after_be.event_end,
+                        billingevent_src.workspace > after_be.workspace,
+                    ),
+                    and_(
+                        billingevent_src.event_start == after_be.event_start,
+                        billingevent_src.event_end == after_be.event_end,
+                        billingevent_src.workspace == after_be.workspace,
+                        BillingItem.sku > after_be.item.sku,
+                    ),
+                    and_(
+                        billingevent_src.event_start == after_be.event_start,
+                        billingevent_src.event_end == after_be.event_end,
+                        billingevent_src.workspace == after_be.workspace,
+                        BillingItem.sku == after_be.item.sku,
+                        billingevent_src.uuid > after,
+                    ),
                 )
+            )
 
         return map(lambda r: r[0], session.execute(query))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -260,7 +260,7 @@ def test_workspace_usage_data_correctly_time_aggregated(
 
         response_pages.append(
             client.get(
-                f"/workspaces/workspace1/accounting/usage-data?limit={page_size}&time_aggregation={aggregation}",
+                f"/workspaces/workspace1/accounting/usage-data?limit={page_size}&time-aggregation={aggregation}",
                 headers={"Authorization": f"Bearer {mock_token}"},
             )
         )
@@ -268,7 +268,7 @@ def test_workspace_usage_data_correctly_time_aggregated(
         after = response_pages[0].json()[-1]["uuid"]
         response_pages.append(
             client.get(
-                f"/workspaces/workspace1/accounting/usage-data?limit={page_size}&after={after}&time_aggregation={aggregation}",
+                f"/workspaces/workspace1/accounting/usage-data?limit={page_size}&after={after}&time-aggregation={aggregation}",
                 headers={"Authorization": f"Bearer {mock_token}"},
             )
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -177,6 +177,20 @@ def test_workspace_usage_data_correctly_paged(db_session: Session, client: TestC
             ],
         ),
         pytest.param(
+            "day",
+            2,
+            [
+                [
+                    {"event_start": "2025-01-01T00:00:00Z", "item": "sku1", "quantity": 1.11},
+                    {"event_start": "2025-01-01T00:00:00Z", "item": "sku2", "quantity": 0.2},
+                ],
+                [
+                    {"event_start": "2025-01-02T00:00:00Z", "item": "sku1", "quantity": 0.2},
+                    {"event_start": "2025-02-02T00:00:00Z", "item": "sku1", "quantity": 0.4},
+                ],
+            ],
+        ),
+        pytest.param(
             "month",
             100,
             [
@@ -284,7 +298,7 @@ def test_workspace_usage_data_correctly_time_aggregated(
 
             assert len(response_json) == len(expected_json)
             for i in range(len(response_json)):
-                print(f"{response_json=}, {expected_json=}")
+                print(f"{response_json[i]=}, {expected_json[i]=}")
                 assert response_json[i]["item"] == expected_json[i]["item"]
                 assert response_json[i]["quantity"] == expected_json[i]["quantity"]
                 assert response_json[i]["event_start"] == expected_json[i]["event_start"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import pprint
 import uuid
 from datetime import datetime
+from http import HTTPStatus
 from unittest.mock import patch
 
 import pytest
@@ -129,6 +130,18 @@ def test_workspace_usage_data_correctly_paged(db_session: Session, client: TestC
         assert datetime.fromisoformat(page1[1]["event_start"]) < datetime.fromisoformat(
             page2[0]["event_start"]
         )
+
+
+def test_page_after_unknown_event_produces_404(db_session: Session, client: TestClient):
+    with patch.object(app.app, "decode_jwt_token", mock_decode_jwt_token):
+        mock_token = "your_mock_jwt_token_here"
+
+        response = client.get(
+            "/workspaces/workspace1/accounting/usage-data?after=a659b597-7522-411d-a2e0-23f7f5629b16",
+            headers={"Authorization": f"Bearer {mock_token}"},
+        )
+
+        assert response.status_code == HTTPStatus.NOT_FOUND
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import delete
 from sqlalchemy.orm.session import Session
@@ -128,6 +129,165 @@ def test_workspace_usage_data_correctly_paged(db_session: Session, client: TestC
         assert datetime.fromisoformat(page1[1]["event_start"]) < datetime.fromisoformat(
             page2[0]["event_start"]
         )
+
+
+@pytest.mark.parametrize(
+    "aggregation,page_size,results",
+    [
+        pytest.param(
+            "",
+            100,
+            [
+                [
+                    {"event_start": "2025-01-01T00:00:00Z", "item": "sku1", "quantity": 0.01},
+                    {"event_start": "2025-01-01T02:00:00Z", "item": "sku1", "quantity": 0.1},
+                    {"event_start": "2025-01-01T02:00:00Z", "item": "sku2", "quantity": 0.2},
+                    {"event_start": "2025-01-01T23:00:00Z", "item": "sku1", "quantity": 1.0},
+                    {"event_start": "2025-01-02T02:00:00Z", "item": "sku1", "quantity": 0.2},
+                    {"event_start": "2025-02-02T00:00:00Z", "item": "sku1", "quantity": 0.4},
+                ],
+                [],
+            ],
+        ),
+        pytest.param(
+            "day",
+            100,
+            [
+                [
+                    {"event_start": "2025-01-01T00:00:00Z", "item": "sku1", "quantity": 1.11},
+                    {"event_start": "2025-01-01T00:00:00Z", "item": "sku2", "quantity": 0.2},
+                    {"event_start": "2025-01-02T00:00:00Z", "item": "sku1", "quantity": 0.2},
+                    {"event_start": "2025-02-02T00:00:00Z", "item": "sku1", "quantity": 0.4},
+                ],
+                [],
+            ],
+        ),
+        pytest.param(
+            "day",
+            3,
+            [
+                [
+                    {"event_start": "2025-01-01T00:00:00Z", "item": "sku1", "quantity": 1.11},
+                    {"event_start": "2025-01-01T00:00:00Z", "item": "sku2", "quantity": 0.2},
+                    {"event_start": "2025-01-02T00:00:00Z", "item": "sku1", "quantity": 0.2},
+                ],
+                [
+                    {"event_start": "2025-02-02T00:00:00Z", "item": "sku1", "quantity": 0.4},
+                ],
+            ],
+        ),
+        pytest.param(
+            "month",
+            100,
+            [
+                [
+                    {"event_start": "2025-01-01T00:00:00Z", "item": "sku1", "quantity": 1.31},
+                    {"event_start": "2025-01-01T00:00:00Z", "item": "sku2", "quantity": 0.2},
+                    {"event_start": "2025-02-01T00:00:00Z", "item": "sku1", "quantity": 0.4},
+                ],
+                [],
+            ],
+        ),
+    ],
+)
+def test_workspace_usage_data_correctly_time_aggregated(
+    db_session: Session, client: TestClient, aggregation, page_size, results
+):
+    ############# Setup
+    db_session.execute(delete(models.BillingEvent))
+    event_uuids, account_uuids, item_uuids = gen_billingitem_data(
+        db_session,
+        [
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2025, 1, 1, 0, 0, 0),
+                "event_end": datetime(2025, 1, 1, 1, 0, 0),
+                "quantity": 0.01,
+                "sku": "sku1",
+            },
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2025, 1, 1, 2, 0, 0),
+                "event_end": datetime(2025, 1, 1, 3, 0, 0),
+                "quantity": 0.1,
+                "sku": "sku1",
+            },
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2025, 1, 1, 23, 0, 0),
+                "event_end": datetime(2025, 1, 2, 0, 0, 0),
+                "quantity": 1,
+                "sku": "sku1",
+            },
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2025, 1, 2, 2, 0, 0),
+                "event_end": datetime(2025, 1, 2, 3, 0, 0),
+                "quantity": 0.2,
+                "sku": "sku1",
+            },
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2025, 2, 2, 0, 0, 0),
+                "event_end": datetime(2025, 2, 3, 0, 0, 0),
+                "quantity": 0.4,
+                "sku": "sku1",
+            },
+            {
+                "workspace": "workspace1",
+                "event_start": datetime(2025, 1, 1, 2, 0, 0),
+                "event_end": datetime(2025, 1, 1, 3, 0, 0),
+                "quantity": 0.2,
+                "sku": "sku2",
+            },
+            {
+                "workspace": "workspace2",
+                "event_start": datetime(2025, 1, 1, 2, 0, 0),
+                "event_end": datetime(2025, 1, 1, 3, 0, 0),
+                "quantity": 0.5,
+                "sku": "sku2",
+            },
+        ],
+    )
+
+    db_session.flush()
+
+    ############# Test
+    with patch.object(app.app, "decode_jwt_token", mock_decode_jwt_token):
+        mock_token = "your_mock_jwt_token_here"
+
+        response_pages = []
+
+        response_pages.append(
+            client.get(
+                f"/workspaces/workspace1/accounting/usage-data?limit={page_size}&time_aggregation={aggregation}",
+                headers={"Authorization": f"Bearer {mock_token}"},
+            )
+        )
+
+        after = response_pages[0].json()[-1]["uuid"]
+        response_pages.append(
+            client.get(
+                f"/workspaces/workspace1/accounting/usage-data?limit={page_size}&after={after}&time_aggregation={aggregation}",
+                headers={"Authorization": f"Bearer {mock_token}"},
+            )
+        )
+
+        ############# Behaviour check
+        for page in [0, 1]:
+            response_page = response_pages[page]
+
+            assert response_page.status_code == 200
+
+            response_json = response_page.json()
+            expected_json = results[page]
+
+            assert len(response_json) == len(expected_json)
+            for i in range(len(response_json)):
+                print(f"{response_json=}, {expected_json=}")
+                assert response_json[i]["item"] == expected_json[i]["item"]
+                assert response_json[i]["quantity"] == expected_json[i]["quantity"]
+                assert response_json[i]["event_start"] == expected_json[i]["event_start"]
 
 
 def test_account_usage_data_returns_correct_items_from_db(db_session: Session, client: TestClient):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,5 +1,5 @@
 import io
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 
 from faker import Faker
@@ -49,7 +49,7 @@ prices:
 
     price = prices[0]
     assert price.price == Decimal("12.34")
-    assert price.valid_from == datetime(2025, 1, 1, 0, 0, 0)
+    assert price.valid_from_utc == datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     assert price.valid_until is None
     assert price.item_id == bi.uuid
 
@@ -102,12 +102,12 @@ prices:
 
     price = prices[0]
     assert price.price == Decimal("12.35")
-    assert price.valid_from == datetime(2025, 1, 1, 0, 0, 0)
-    assert price.valid_until == datetime(2025, 1, 2, 0, 0, 0)
+    assert price.valid_from_utc == datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    assert price.valid_until_utc == datetime(2025, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
     assert price.item_id == bi.uuid
 
     price = prices[1]
     assert price.price == Decimal("11.0")
-    assert price.valid_from == datetime(2025, 1, 2, 0, 0, 0)
+    assert price.valid_from_utc == datetime(2025, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
     assert price.valid_until is None
     assert price.item_id == bi.uuid


### PR DESCRIPTION
This adds an API parameter to the accounting usage data which requests that data is time aggregated by day or month.

This should allow the accounting UI to show more useful and easily navigable data. The list is otherwise extremely long and entries cover variable lengths of time.